### PR TITLE
fix: escape \\b in packagePatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
             "\\bhexo\\b",
             "chexo"
           ],
-          "groupName": "Hexo-related packages",
+          "groupName": "Hexo-related",
           "automerge": true
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renovate-config-meteor-docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -20,7 +20,7 @@
       "packageRules": [
         {
           "packagePatterns": [
-            "\bhexo\b",
+            "\\bhexo\\b",
             "chexo"
           ],
           "groupName": "Hexo-related packages",


### PR DESCRIPTION
Renovate needs the \ escaped as we pass it as a string to `new RegeExp()`. Please merge and publish.