### PR TITLE
Set PR limit to 10/hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "extends": [
         "config:base"
       ],
+      "prHourlyLimit": 10,
       "reviewers": [
         "abernix"
       ],


### PR DESCRIPTION
Sets Renovate's hourly rate limit for new PRs to 10.